### PR TITLE
Bump egui to 0.24.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
-egui = { version = "0.23", default-features = false }
+egui = { version = "0.24.1", default-features = false }
 
 [dev-dependencies]
-eframe = "0.23"
+eframe = "0.24.1"


### PR DESCRIPTION
Need the bump for 
https://github.com/mkrueger/icy_draw
and 
https://github.com/mkrueger/icy_term