### PR TITLE
Updated egui/eframe versions from 0.31 to 0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-bind"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Library for showing keybinds"
 license = "MIT"
@@ -12,7 +12,7 @@ serde = ["dep:serde", "egui/serde"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
-egui = { version = "0.31", default-features = false }
+egui = { version = "0.33", default-features = false }
 
 [dev-dependencies]
-eframe = "0.31"
+eframe = "0.33"

--- a/README.md
+++ b/README.md
@@ -6,50 +6,59 @@ Library for showing key and pointer binds
 # Installation
 ```toml
 [dependencies]
-egui-bind = "0.14"
+egui-bind = "0.16"
 
 # Or if you wish for your binds to be serializable
 # [dependencies]
-# egui-bind = { version = "0.14", features = ["serde"] }
+# egui-bind = { version = "0.16", features = ["serde"] }
 ```
 
 # Example
 ```rust
 // Foreword: You can find this example in `examples/bind.rs`
+use eframe::{run_native, App, CreationContext, Frame, NativeOptions};
+use egui::{Context, Modifiers, Window};
+use egui_bind::{Bind, BindTarget, KeyOrPointer};
+
+type Binding = Option<(KeyOrPointer, Modifiers)>;
+
 #[derive(Default)]
 struct ExampleApp {
     // This can also be serialized with `serde`. You just
     // need to enable `serde` feature.
-    bind: Option<(KeyOrPointer, Modifiers)>,
+    bind: Binding,
     count: usize,
+    check: bool,
 }
 
 impl App for ExampleApp {
     fn update(&mut self, ctx: &Context, _: &mut Frame) {
-        Window::new("Example")
-            .show(ctx, |ui| {
-                // Order matters, If you were to put this if case
-                // after the bind was shown, then it would trigger `self.cout += 1`
-                // on the same frame user assigned a new bind, which may not be the
-                // desired behavior. But you can mitigate this by using the return
-                // value of a `Bind::show` as shown below with `println!`.
-                if self.bind.pressed(ui.input()) {
-                    self.count += 1;
-                }
+        Window::new("Example").show(ctx, |ui| {
+            // Order matters, If you were to put this if case
+            // after the bind was shown, then it would trigger `self.count += 1`
+            // on the same frame user assigned a new bind, which may not be the
+            // desired behavior. But you can mitigate this by using the return
+            // value of a `Bind::show` as shown below with `println!`.
+            if self.bind.pressed(ctx) {
+                self.count += 1;
+                self.check = !self.check;
+            }
 
-                // `Bind::new` accepts a reference to a type that implements `BindTarget`
-                // Most common of those are:
-                // `Key`, `PointerButton`, `KeyOrPointer`, `(BindTarget, Modifiers)`
-                // `Option<BindTarget>`
-                let assigned = Bind::new("_test", &mut self.bind).show(ui);
+            let r = ui.checkbox(&mut self.check, "Check");
+            if egui_bind::show_bind_popup(ui, &mut self.bind, "check_popup", &r) {
+                println!("Rebinded from popup");
+            }
 
-                // Here it checks if the bind was pressed but not assigned on the same frame.
-                if !assigned && self.bind.pressed(ui.input()) {
-                    println!("I was pressed");
-                }
+            // `Bind::new` accepts a reference to a type that implements `BindTarget`
+            // Most common of those are:
+            // `Key`, `PointerButton`, `KeyOrPointer`, `(BindTarget, Modifiers)`
+            // Or `Option<T>` where `T` is the type mentioned above.
+            if ui.add(Bind::new("_test", &mut self.bind)).changed() {
+                println!("Rebinded!");
+            }
 
-                ui.label(format!("Counter: {}", self.count));
-            });
+            ui.label(format!("Counter: {}", self.count));
+        });
     }
 }
 ```


### PR DESCRIPTION
Updated Cargo.toml

Updated deprecated function calls in lib.rs

Updated README.md example (included in lib.rs) to stop `cargo test` from failing